### PR TITLE
JobBuilder2: Update DslFactory API usage

### DIFF
--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/JobBuilder.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/JobBuilder.groovy
@@ -28,7 +28,7 @@ class JobBuilder {
             case MultiJob:
                 return dslFactory.multiJob(name, closure)
             case WorkflowJob:
-                return dslFactory.workflowJob(name, closure)
+                return dslFactory.pipelineJob(name, closure)
             default:
                 throw new RuntimeException("Job type ${jobClass} is not supported.")
         }
@@ -54,7 +54,7 @@ class JobBuilder {
         return build(MultiJob, closure)
     }
 
-    WorkflowJob buildWorkflowJob(@DelegatesTo(WorkflowJob) Closure closure) {
+    WorkflowJob buildPipelineJob(@DelegatesTo(WorkflowJob) Closure closure) {
         return build(WorkflowJob, closure)
     }
 

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/JobBuilder2.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/JobBuilder2.groovy
@@ -50,7 +50,7 @@ class JobBuilder2 {
             case MultiJob:
                 return dslFactory.multiJob(fullJobName(), dslClosure)
             case WorkflowJob:
-                return dslFactory.workflowJob(fullJobName(), dslClosure)
+                return dslFactory.pipelineJob(fullJobName(), dslClosure)
             default:
                 throw new RuntimeException("Job type ${jobClass} is not supported.")
         }
@@ -126,7 +126,7 @@ class JobBuilder2 {
      *
      * @param closure
      */
-    void workflowJob(@DelegatesTo(WorkflowJob) Closure closure = null) {
+    void pipelineJob(@DelegatesTo(WorkflowJob) Closure closure = null) {
         checkJobClassNull()
         if (closure != null) {
             addDsl(closure)
@@ -192,7 +192,7 @@ class JobBuilder2 {
 
      * @param closure
      */
-    void addWorkflowDsl(@DelegatesTo(WorkflowJob) Closure closure) {
+    void addPipelineDsl(@DelegatesTo(WorkflowJob) Closure closure) {
         addDsl(closure)
     }
 


### PR DESCRIPTION
Version 1.54 of job-dsl-core removed `DslFactory#workflowJob` in favor of `DslFactory#pipelineJob`, see [this](https://github.com/jenkinsci/job-dsl-plugin/commit/fb3e40fd8). So using `JobBuilder2` with  `jobClass = WorkflowJob` crashes.

Strictly speaking this would require a major release, but the method didn't work for some time. I could add `JobBuilder2#workflowJob` back and use `JobBuilder2#pipelineJob` internally.