### PR TITLE
Use localGroovy() instead of fixed Groovy version dependency

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -37,7 +37,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.10'
+    compile localGroovy()
     compile "org.jenkins-ci.plugins:job-dsl-core:1.61"
     compile 'org.jenkins-ci:version-number:1.3'
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -38,7 +38,7 @@ sourceSets {
 
 dependencies {
     compile localGroovy()
-    compile "org.jenkins-ci.plugins:job-dsl-core:1.61"
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.61'
     compile 'org.jenkins-ci:version-number:1.3'
 
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {


### PR DESCRIPTION
This improves compatibility with different Gradle versions.