### PR TITLE
Resolve #25: Use localGroovy() instead of hardcoding the Groovy version

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -37,8 +37,10 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.11'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.61'
+    compile localGroovy()
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.61') {
+        exclude(module: 'groovy-all')
+    }
     compile 'org.jenkins-ci:version-number:1.3'
 
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {

--- a/plugin/src/functionalTest/resources/generateXml/build-add-custom-source-set.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build-add-custom-source-set.gradle
@@ -13,3 +13,7 @@ sourceSets {
         }
     }
 }
+
+dependencies {
+    compile localGroovy()
+}

--- a/plugin/src/functionalTest/resources/generateXml/build-replace-source-set.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build-replace-source-set.gradle
@@ -13,3 +13,7 @@ sourceSets {
         }
     }
 }
+
+dependencies {
+    compile localGroovy()
+}

--- a/plugin/src/functionalTest/resources/generateXml/build-with-configuration.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build-with-configuration.gradle
@@ -21,3 +21,7 @@ jobdsl {
         }
     }
 }
+
+dependencies {
+    compile localGroovy()
+}

--- a/plugin/src/functionalTest/resources/generateXml/build.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build.gradle
@@ -5,3 +5,7 @@ buildscript {
 }
 
 apply plugin: 'com.here.jobdsl'
+
+dependencies {
+    compile localGroovy()
+}

--- a/plugin/src/functionalTest/resources/updateJenkins/build.gradle
+++ b/plugin/src/functionalTest/resources/updateJenkins/build.gradle
@@ -5,3 +5,7 @@ buildscript {
 }
 
 apply plugin: 'com.here.jobdsl'
+
+dependencies {
+    compile localGroovy()
+}


### PR DESCRIPTION
This was already tried in 17bdf9a before and reverted in afb98ca because
all functional tests failed. The problem was that the build files for
the tests did not add a localGroovy() dependency. But since localGroovy()
does not declare a real dependency and instead only adds the local Groovy
to the classpath all users of the plugin (and also the tests) have to add
localGroovy() to their dependencies.