### PR TITLE
Fix the order of expected and actual values for XML comparison

### DIFF
--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
@@ -25,7 +25,7 @@ class GenerateXmlTest extends AbstractTaskTest {
         generatedFile.file
         def actualText = generatedFile.text
         def expectedText = readResource('generateXml/empty-freestyle-job.xml')
-        XMLUnit.compareXML(actualText, expectedText).identical()
+        XMLUnit.compareXML(expectedText, actualText).identical()
     }
 
     def 'empty list view is generated correctly'() {
@@ -45,7 +45,7 @@ class GenerateXmlTest extends AbstractTaskTest {
         generatedFile.file
         def actualText = generatedFile.text
         def expectedText = readResource('generateXml/empty-list-view.xml')
-        XMLUnit.compareXML(actualText, expectedText).identical()
+        XMLUnit.compareXML(expectedText, actualText).identical()
     }
 
     def 'folder is generated correctly'() {
@@ -65,7 +65,7 @@ class GenerateXmlTest extends AbstractTaskTest {
         generatedFile.file
         def actualText = generatedFile.text
         def expectedText = readResource('generateXml/folder.xml')
-        XMLUnit.compareXML(actualText, expectedText).identical()
+        XMLUnit.compareXML(expectedText, actualText).identical()
     }
 
     def 'job in folder is generated in the right subfolder'() {

--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTest.groovy
@@ -51,8 +51,8 @@ class UpdateJenkinsTest extends AbstractTaskTest {
         Item item = jenkinsRule.jenkins.getItemByFullName('job')
         item instanceof FreeStyleProject
         XMLUnit.compareXML(
-                item.configFile.asString(),
-                readResource('updateJenkins/empty-freestyle-job.xml')
+                readResource('updateJenkins/empty-freestyle-job.xml'),
+                item.configFile.asString()
         ).identical()
     }
 
@@ -70,7 +70,10 @@ class UpdateJenkinsTest extends AbstractTaskTest {
         view instanceof ListView
         def output = new ByteArrayOutputStream()
         view.writeXml(output)
-        XMLUnit.compareXML(output.toString(), readResource('updateJenkins/empty-list-view.xml')).identical()
+        XMLUnit.compareXML(
+                readResource('updateJenkins/empty-list-view.xml'),
+                output.toString()
+        ).identical()
     }
 
     @WithPlugin('cloudbees-folder-6.1.0.hpi')
@@ -87,8 +90,8 @@ class UpdateJenkinsTest extends AbstractTaskTest {
         Item item = jenkinsRule.jenkins.getItemByFullName('folder')
         item instanceof Folder
         XMLUnit.compareXML(
-                item.configFile.asString(),
-                readResource('updateJenkins/folder.xml')
+                readResource('updateJenkins/folder.xml'),
+                item.configFile.asString()
         ).identical()
     }
 


### PR DESCRIPTION
The first "control" argument should be the expected value, the second
"test" argument should be the actual value.