### PR TITLE
Make file I/O always use UTF-8 encoding

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'maven-publish'
-apply plugin: 'idea'
 
 ext {
     jenkinsVersion = '2.71'
@@ -68,12 +67,6 @@ dependencies {
     jenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:6.1.0'
     jenkinsPlugins 'org.jenkins-ci.plugins:gradle:1.22' // Old version used to test reporting of outdated plugins.
     jenkinsPlugins 'org.jenkins-ci.plugins:gitlab-plugin:1.4.5' // Used to test reporting of deprecated plugins.
-}
-
-idea {
-    module {
-        scopes.TEST.plus += [configurations.functionalTestCompile]
-    }
 }
 
 task resolveTestPlugins(type: Copy) {

--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/AbstractTaskTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/AbstractTaskTest.groovy
@@ -30,11 +30,11 @@ class AbstractTaskTest extends Specification {
     }
 
     def readBuildGradle(String path) {
-        readResource(path).replace('CLASSPATH_STRING', classpathString())
+        readResource(path).replace('CLASSPATH_STRING', classpathString()).getBytes('UTF-8')
     }
 
     def copyResourceToTestDir(String from, String to = 'src/jobdsl/jobdsl.groovy') {
-        testProjectDir.newFile(to) << readResource(from)
+        testProjectDir.newFile(to) << readResource(from).getBytes('UTF-8')
     }
 
     def setup() {

--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/AbstractTaskTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/AbstractTaskTest.groovy
@@ -26,7 +26,7 @@ class AbstractTaskTest extends Specification {
     }
 
     def readResource(String path) {
-        getClass().classLoader.getResource(path).text
+        getClass().classLoader.getResource(path).getText('UTF-8')
     }
 
     def readBuildGradle(String path) {

--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
@@ -23,7 +23,7 @@ class GenerateXmlTest extends AbstractTaskTest {
 
         def generatedFile = new File(testProjectDir.root, 'build/jobdsl/xml/job.xml')
         generatedFile.file
-        def actualText = generatedFile.text
+        def actualText = generatedFile.getText('UTF-8')
         def expectedText = readResource('generateXml/empty-freestyle-job.xml')
         XMLUnit.compareXML(expectedText, actualText).identical()
     }
@@ -43,7 +43,7 @@ class GenerateXmlTest extends AbstractTaskTest {
 
         def generatedFile = new File(testProjectDir.root, 'build/jobdsl/xml/view.xml')
         generatedFile.file
-        def actualText = generatedFile.text
+        def actualText = generatedFile.getText('UTF-8')
         def expectedText = readResource('generateXml/empty-list-view.xml')
         XMLUnit.compareXML(expectedText, actualText).identical()
     }
@@ -63,7 +63,7 @@ class GenerateXmlTest extends AbstractTaskTest {
 
         def generatedFile = new File(testProjectDir.root, 'build/jobdsl/xml/folder.xml')
         generatedFile.file
-        def actualText = generatedFile.text
+        def actualText = generatedFile.getText('UTF-8')
         def expectedText = readResource('generateXml/folder.xml')
         XMLUnit.compareXML(expectedText, actualText).identical()
     }

--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
@@ -268,4 +268,24 @@ class GenerateXmlTest extends AbstractTaskTest {
         result.output.contains('No files found in JobDSL source folder.')
     }
 
+    def 'groovy postbuild step with UTF-8 characters is generated correctly'() {
+        given:
+        buildFile << readBuildGradle('generateXml/build.gradle')
+        copyResourceToTestDir('generateXml/groovy-postbuild-with-utf-8.groovy')
+
+        when:
+        def result = gradleRunner
+                .withArguments('dslGenerateXml')
+                .build()
+
+        then:
+        result.task(':dslGenerateXml').outcome == TaskOutcome.SUCCESS
+
+        def generatedFile = new File(testProjectDir.root, 'build/jobdsl/xml/job.xml')
+        generatedFile.file
+        def actualText = generatedFile.getText('UTF-8')
+        def expectedText = readResource('generateXml/groovy-postbuild-with-utf-8.xml')
+        XMLUnit.compareXML(expectedText, actualText).identical()
+    }
+
 }

--- a/plugin/src/functionalTest/resources/generateXml/groovy-postbuild-with-utf-8.groovy
+++ b/plugin/src/functionalTest/resources/generateXml/groovy-postbuild-with-utf-8.groovy
@@ -1,0 +1,9 @@
+freeStyleJob('job') {
+        publishers {
+            groovyPostBuild('''\
+                def summary = manager.createSummary('completed.gif')
+                summary.appendText('✔' /* UTF-8 encoded checkmark */, false, false, false, 'green')
+                summary.appendText('✖' /* UTF-8 encoded cross */, false, false, false, 'red')
+                '''.stripIndent())
+        }
+}

--- a/plugin/src/functionalTest/resources/generateXml/groovy-postbuild-with-utf-8.xml
+++ b/plugin/src/functionalTest/resources/generateXml/groovy-postbuild-with-utf-8.xml
@@ -1,0 +1,27 @@
+<project>
+    <actions></actions>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties></properties>
+    <scm class='hudson.scm.NullSCM'></scm>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers></triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <builders></builders>
+    <publishers>
+        <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
+            <script>
+                <script>def summary = manager.createSummary(&apos;completed.gif&apos;)
+summary.appendText(&apos;✔&apos; /* UTF-8 encoded checkmark */, false, false, false, &apos;green&apos;)
+summary.appendText(&apos;✖&apos; /* UTF-8 encoded cross */, false, false, false, &apos;red&apos;)
+</script>
+                <sandbox>false</sandbox>
+            </script>
+            <behavior>0</behavior>
+        </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
+    </publishers>
+    <buildWrappers></buildWrappers>
+</project>

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/AbstractTaskRunner.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/AbstractTaskRunner.groovy
@@ -41,7 +41,7 @@ abstract class AbstractTaskRunner {
 
         runProperties['inputFiles'].split(File.pathSeparator).each { String filename ->
             println "Loading ${filename}"
-            ScriptRequest scriptRequest = new ScriptRequest(new File(filename).text)
+            ScriptRequest scriptRequest = new ScriptRequest(new File(filename).getText('UTF-8'))
             loader.runScripts([scriptRequest])
         }
 

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/GenerateXmlRunner.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/GenerateXmlRunner.groovy
@@ -36,6 +36,7 @@ class GenerateXmlRunner extends AbstractTaskRunner {
     void writeXml(File outputDirectory, String name, String xml) {
         def targetDirectory = outputDirectory
         def fileName = name
+
         if (name.contains('/')) {
             def lastIndex = name.lastIndexOf('/')
             def subDirectory = name[0..lastIndex]
@@ -43,8 +44,10 @@ class GenerateXmlRunner extends AbstractTaskRunner {
             targetDirectory.mkdirs()
             fileName = name.drop(lastIndex + 1)
         }
-        def xmlFile = new File("${targetDirectory}/${fileName}.xml")
-        xmlFile.write(xml)
+
+        new File("${targetDirectory}/${fileName}.xml").withWriter('UTF-8') {
+            it.write(xml)
+        }
     }
 
 }

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/GroovySeedJobBuilder.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/util/GroovySeedJobBuilder.groovy
@@ -41,7 +41,7 @@ class GroovySeedJobBuilder extends JobBuilder {
      * Views in the Jenkins root will always be updated, views inside folders will always be re-created.<br>
      * <em>Only change this value if you know what you are doing!</em>
      */
-    String seedJobGroovyScript = getClass().classLoader.getResource('seedJobGroovyScript.groovy').text
+    String seedJobGroovyScript = getClass().classLoader.getResource('seedJobGroovyScript.groovy').getText('UTF-8')
 
     GroovySeedJobBuilder(DslFactory dslFactory) {
         super(dslFactory)

--- a/plugin/src/main/resources/seedJobGroovyScript.groovy
+++ b/plugin/src/main/resources/seedJobGroovyScript.groovy
@@ -22,7 +22,7 @@ def updateItem(Item item, String name, FilePath file) {
 
     try {
         String oldConfig = item.getConfigFile().asString()
-        String newConfig = file.read().text
+        String newConfig = file.read().getText('UTF-8')
         Diff diff = XMLUnit.compareXML(oldConfig, newConfig)
         if (diff.identical()) {
             println "  Item ${name} did not change"


### PR DESCRIPTION
Previously, using UTF-8 characters in job definitions did not work on OSes whose standard system encoding is not UTF-8, like Windows. Be explicitly about using UTF-8 in all places to fix this.